### PR TITLE
Docker for viper now compatible with cgl standards

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -11,6 +11,7 @@ RUN apt-get -y update && apt-get install -y make
 #RUN apt-get -y update && apt-get install -y r-base r-base-dev
 
 RUN apt-get -y install libcurl4-openssl-dev
+WORKDIR /home
 #setup R configs
 RUN echo "r <- getOption('repos'); r['CRAN'] <- 'http://cran.us.r-project.org'; options(repos = r);" > ~/.Rprofile
 RUN Rscript -e "source('http://bioconductor.org/biocLite.R'); biocLite('mygene')"
@@ -20,9 +21,8 @@ RUN Rscript -e "source('http://bioconductor.org/biocLite.R'); biocLite('viper');
 RUN Rscript -e "source('http://bioconductor.org/biocLite.R'); biocLite('GenomicFeatures')"
 RUN Rscript -e "install.packages('getopt')"
 
-
 RUN rm -rf UCSC_VIPER
-RUN git clone http://github.com/epaull/UCSC_VIPER.git
+RUN git clone http://github.com/arkal/UCSC_VIPER.git
 
-
-ENTRYPOINT ["/UCSC_VIPER/bin/run-viper.R"]
+WORKDIR /data
+ENTRYPOINT ["sh", "/home/UCSC_VIPER/docker/viper_wrapper.sh"]

--- a/docker/viper_wrapper.sh
+++ b/docker/viper_wrapper.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -e
+
+finish() {
+    # Fix ownership of output files
+    UID=$(stat -c '%u:%g' /data)
+    chown -R $UID /data
+}
+trap finish EXIT
+
+# Call tool with parameters
+/usr/bin/Rscript /home/UCSC_VIPER/bin/run-viper.R "$@" 


### PR DESCRIPTION
1. Added a wrapper script to Launch Viper within the docker container (Handles exceptions in
   the script and causes docker to exit with the same return code as the script)
2. the WORKDIR is now set as /data. Using this tool requires the input file to be mounted with -v
   /path/to/file/dirname:/data
3. UCSC_VIPER is in /home making it easy to find in case anyone ever digs into the container.
